### PR TITLE
fix: Jupyter lab python autocomplete

### DIFF
--- a/data-science/jupyterlab_python/requirements.txt
+++ b/data-science/jupyterlab_python/requirements.txt
@@ -5,3 +5,4 @@ seaborn==0.10.*
 scipy==1.*
 Keras==2.4.*
 xgboost==1.2.*
+jedi==0.17.2


### PR DESCRIPTION
Last jedi release is incompatible with IPython, so we have to install a specific version.

See more in this issue:
https://github.com/ipython/ipython/issues/12740